### PR TITLE
refactor: separate our decompressor so it can be called from multiple places

### DIFF
--- a/stream_unzip.py
+++ b/stream_unzip.py
@@ -11,7 +11,6 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
     def get_byte_readers(iterable):
         # Return functions to return/"replace" bytes from/to the iterable
         # - _yield_all: yields chunks as they come up (often for a "body")
-        # - _yield_num: yields chunks as the come up, up to a fixed number of bytes
         # - _get_num: returns a single `bytes` of a given length
         # - _return_unused: puts "unused" bytes "back", to be retrieved by a yield/get call
 
@@ -65,7 +64,7 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
                 chunk = prev_chunk[-num_unused:] + chunk[offset:]
                 offset = 0
 
-        return _yield_all, _yield_num, _get_num, _return_unused
+        return _yield_all, _get_num, _return_unused
 
     def get_dummy_decompressor(num_bytes):
         num_decompressed = 0
@@ -107,7 +106,7 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
 
         return _decompress, _is_done, _num_unused
 
-    def yield_file(yield_all, yield_num, get_num, return_unused):
+    def yield_file(yield_all, get_num, return_unused):
 
         def get_flag_bits(flags):
             for b in flags:
@@ -241,12 +240,12 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
 
         return file_name, uncompressed_size, with_crc_32_check(is_zip64, decompressed_bytes)
 
-    yield_all, yield_num, get_num, return_unused = get_byte_readers(zipfile_chunks)
+    yield_all, get_num, return_unused = get_byte_readers(zipfile_chunks)
 
     while True:
         signature = get_num(len(local_file_header_signature))
         if signature == local_file_header_signature:
-            yield yield_file(yield_all, yield_num, get_num, return_unused)
+            yield yield_file(yield_all, get_num, return_unused)
         elif signature == central_directory_signature:
             for _ in yield_all():
                 pass

--- a/stream_unzip.py
+++ b/stream_unzip.py
@@ -164,7 +164,6 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
 
         def no_decrypt_decompress(chunks, decompress, is_done, num_unused):
             for chunk in chunks:
-
                 yield from decompress(chunk)
                 if is_done():
                     break

--- a/stream_unzip.py
+++ b/stream_unzip.py
@@ -208,7 +208,7 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
             Struct('<QQ').unpack(get_extra_data(extra, zip64_size_signature)) if is_zip64 else \
             (uncompressed_size, compressed_size)
         uncompressed_size = \
-            None if has_data_descriptor else \
+            None if has_data_descriptor and compression == 8 else \
             uncompressed_size
 
         encrypted_bytes = \

--- a/test.py
+++ b/test.py
@@ -316,7 +316,7 @@ class TestStreamUnzip(unittest.TestCase):
         ]
         self.assertEqual(files, [
             (b'compressed.txt', None, b'Some content to be password protected\n' * 14),
-            (b'uncompressed.txt', None, b'Some content to be password protected'),
+            (b'uncompressed.txt', 37, b'Some content to be password protected'),
         ])
 
     def test_password_protected_file_bad_password(self):


### PR DESCRIPTION
Although "for the most part" decryption is before decompression, for AES-encrypted files, this is not strictly true.

One subtle part of it, the authentication code/hmac check, has to come _after_ decompression, since the location of the end of the compressed stream is not known until after decompression. The location of the end of the compressed stream is needed to be known to work out what bytes to include in the hmac calculation, and to find the hmac code to compare to, which is after the end of the encrypted + compressed bytes.

An added complication is that the although hmac check has to come after decryption+decompression,  it's done on the not-yet decrypted bytes, so "quite far back" if viewing the process as a pipeline. So the decryption seems to be really intertwined with decompressing. So, that intertwined-ness is expressed in code, where the decryption explicitly calls (slightly abstracted) decryption methods and can respond as needed.