### PR TITLE
feat: raise UnfinishedIterationError if iteration is unfinished

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ def zipped_chunks():
 
 for file_name, file_size, unzipped_chunks in stream_unzip(zipped_chunks(), password=b'my-password'):
     for chunk in unzipped_chunks:
+        # All chunks must be iterated, otherwise an UnfinishedIterationError will be raised
         print(chunk)
 ```
 
@@ -43,6 +44,12 @@ Exceptions raised by the source iterable are passed through `stream_unzip` uncha
   - **UnzipError**
 
     Base class for all explicitly-thrown exceptions
+
+    - **InvalidOperationError**
+
+      - **UnfinishedIterationError**
+
+      The chunks of a member file have not all been iterated.
 
     - **UnzipValueError** (also inherits from the **ValueError** built-in)
 

--- a/test.py
+++ b/test.py
@@ -7,6 +7,7 @@ import zipfile
 
 from stream_unzip import (
     stream_unzip,
+    UnfinishedIterationError,
     TruncatedDataError,
     UnsupportedFlagsError,
     UnsupportedCompressionTypeError,
@@ -107,6 +108,38 @@ class TestStreamUnzip(unittest.TestCase):
                     combined = b''.join(chunks)
 
                 self.assertEqual(combined, content)
+
+    def test_exception_on_skip(self):
+        rnd = random.Random()
+        rnd.seed(1)
+
+        methods = [zipfile.ZIP_DEFLATED, zipfile.ZIP_STORED]
+        input_sizes = [1, 7, 65536]
+        output_sizes = [1, 7, 65536]
+
+        contents = [
+            b'short',
+            b''.join([uuid.UUID(int=rnd.getrandbits(128), version=4).hex.encode() for _ in range(0, 10000)])
+        ]
+
+        def yield_input(content, method, input_size):
+            file = io.BytesIO()
+            with zipfile.ZipFile(file, 'w', method) as zf:
+                zf.writestr('first.txt', content)
+                zf.writestr('second.txt', content)
+
+            zip_bytes = file.getvalue()
+
+            for i in range(0, len(zip_bytes), input_size):
+                yield zip_bytes[i:i + input_size]
+
+        combinations_iter = itertools.product(contents, methods, input_sizes, output_sizes)
+        for content, method, input_size, output_size in combinations_iter:
+            with self.subTest(content=content[:5], method=method, input_size=input_size, output_size=output_size):
+                with self.assertRaises(UnfinishedIterationError):
+                    for name, size, chunks in stream_unzip(yield_input(content, method, input_size), chunk_size=output_size):
+                        if name == b'first.txt':
+                            continue
 
     def test_output_size(self):
         rnd = random.Random()


### PR DESCRIPTION
Addresses some of the concerns at https://github.com/uktrade/stream-unzip/issues/21 (but does not change the API to allow not fully iterating over the bytes of member files)