### PR TITLE
feat: work with most files created by java that have members 4294967295 bytes long

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Exceptions raised by the source iterable are passed through `stream_unzip` uncha
 
             The CRC32 integrity check on decrypted and decompressed bytes failed.
 
+          - **SizeIntegrityError**
+
+            - **UncompressedSizeIntegrityError**
+
+              The amount of uncompressed bytes of a member file did not match its metadata.
+
+            - **CompressedSizeIntegrityError**
+
+              The amount of compressed bytes of a member file did not match its metadata.
+
         - **TruncatedDataError**
 
           The stream of bytes ended unexpectedly.

--- a/test.py
+++ b/test.py
@@ -653,15 +653,12 @@ class TestStreamUnzip(unittest.TestCase):
             with open('fixtures/java_19_0_1_zip64_limit.zip', 'rb') as f:
                 yield f.read()
 
-        # This is more to document the behaviour of the code. Ideally no exception
-        # would be raised and the ZIP decompressed. However, when compressed data
-        # is exactly 4294967295 bytes in length, Java uses a ZIP64 data descriptor
-        # However, it looks like InfoZIP can make a ZIP32 data descriptor for this
-        # case. Not sure on the best course of action
-        with self.assertRaises(UnexpectedSignatureError):
-            for name, size, chunks in stream_unzip(yield_input()):
-                for _ in chunks:
-                    pass
+        l = 0
+        for name, size, chunks in stream_unzip(yield_input()):
+            for chunk in chunks:
+                l += len(chunk)
+
+        self.assertEqual(l, 4294967295)
 
     def test_java_zip64_limit_plus_one(self):
         def yield_input():


### PR DESCRIPTION
 We can't up front be sure of the format of the data descriptor in all cases. So we inch our way through the stream checking what we think is the data descriptor against the known compressed and uncompressed size of the data itself. If there is a match: that's "probably" the data descriptor.

The issue is that we could have cases where the we get a match just because the values happen to match. The cases are not likely, but so far I don't see a reason why they're impossible.