### PR TITLE
feat: improve detection of data descriptor

### DIFF
--- a/stream_unzip.py
+++ b/stream_unzip.py
@@ -44,22 +44,6 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
         offset_from_start = 0
         it = iter(iterable)
 
-        def _yield_all():
-            nonlocal chunk, offset, offset_from_start
-
-            while True:
-                if offset == len(chunk):
-                    try:
-                        chunk = next(it)
-                    except StopIteration:
-                        break
-                    else:
-                        offset = 0
-                to_yield = min(len(chunk) - offset, chunk_size)
-                offset = offset + to_yield
-                offset_from_start += to_yield
-                yield chunk[offset - to_yield:offset]
-
         def _yield_num(num):
             nonlocal chunk, offset, offset_from_start
 
@@ -72,6 +56,12 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536):
                 num -= to_yield
                 offset_from_start += to_yield
                 yield chunk[offset - to_yield:offset]
+
+        def _yield_all():
+            try:
+                yield from _yield_num(float('inf'))
+            except TruncatedDataError:
+                pass
 
         def _get_num(num):
             return b''.join(_yield_num(num))


### PR DESCRIPTION
The data descriptor is a section after the end of the the member data in some ZIP files. Whether or not there is a data descriptor is always known up front, but the exact format is not. So we have to use a heuristic to detect it. There is unfortunately a theoretical possibility that as we walk the stream we would match too early because values just happen to match.

It's already fairly unlikely, but this commit reduces the chance even more by ensuring that after what we think is the data descriptor is what seems to be another member file, or the central directory header.

Because this requires a "peek" ahead in the stream, we need a way of putting data back to be read again by later code.