### PR TITLE
feat: add bz2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ In addition to being memory efficient, stream-unzip supports:
 - Legacy-encrypted ZIP files. This is also known as ZipCrypto/Zip 2.0.
 
 - ZIP files created by Java's ZipOutputStream that are larger than 4GiB. At the time of writing libarchive-based stream readers cannot read these without error.
+
+- BZip2-compressed ZIPs.
 <!-- --8<-- [end:features] -->
 
 ---

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -59,6 +59,10 @@ Exceptions raised by the source iterable are passed through `stream_unzip` uncha
 
             - **UncompressError**
 
+              - **BZ2Error**
+
+                An error in the bz2-compressed data meant it could not be decompressed.
+
               - **DeflateError**
 
                 An error in the deflate-compressed data meant it could not be decompressed.

--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ class TestStreamUnzip(unittest.TestCase):
         rnd = random.Random()
         rnd.seed(1)
 
-        methods = [zipfile.ZIP_DEFLATED, zipfile.ZIP_STORED]
+        methods = [zipfile.ZIP_BZIP2, zipfile.ZIP_DEFLATED, zipfile.ZIP_STORED]
         input_sizes = [1, 7, 65536]
         output_sizes = [1, 7, 65536]
 


### PR DESCRIPTION
This wasn't really considered initially since ZIP files compressed with bz2 aren't usually seen in the wild. However

- it's not that much code
- it fits in with the existing internal architecture well
- Python's zipfile module supports it
- we don't need to add any dependencies beyond Python's standard library
- from https://github.com/uktrade/stream-unzip/issues/39 there is at least one use case