### PR TITLE
feat: allow disabling of zip64

### DIFF
--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -57,6 +57,10 @@ Exceptions raised by the source iterable are passed through `stream_unzip` uncha
 
                 - **UnsupportedCompressionTypeError**
 
+                - **UnsupportedZip64Error**
+
+                   A Zip64 member file has been encounted but support has been disabled.
+
             - **UncompressError**
 
               - **BZ2Error**

--- a/test.py
+++ b/test.py
@@ -11,6 +11,7 @@ from stream_unzip import (
     TruncatedDataError,
     UnsupportedFlagsError,
     UnsupportedCompressionTypeError,
+    UnsupportedZip64Error,
     UnexpectedSignatureError,
     HMACIntegrityError,
     CRC32IntegrityError,
@@ -398,6 +399,18 @@ class TestStreamUnzip(unittest.TestCase):
 
         self.assertEqual(size, 5000000000)
         self.assertEqual(num_received_bytes, 5000000000)
+
+    def test_python_zip64_disabled(self):
+        def yield_input():
+            with open('fixtures/python38_zip64.zip', 'rb') as f:
+                while True:
+                    chunk = f.read(65536)
+                    if not chunk:
+                        break
+                    yield chunk
+
+        with self.assertRaises(UnsupportedZip64Error):
+            next(iter(stream_unzip(yield_input(), allow_zip64=False)))
 
     def test_macos_single_file(self):
         def yield_input():


### PR DESCRIPTION
This is to allow stream-unzip to be used in the testing of libraries that should make zip32 files for compatibility reasons.

Note that at the time of writing zip64 support is not ubiquitous. For example, Libre Office doesn't seem to support files zipped with zip64, and Safari seems to have an issue where if the first file from an zip is zip64, it _only_ unzips that one. So while this is a niche feature, it's still a useful one in some circumstances - to test that certain files really are zip32.