### PR TITLE
point at stream-unzip rather than stream-zip

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ Python 3.5+
 
 ## Installation
 
-You can install stream-unzip and its dependencies from [PyPI](https://pypi.org/project/stream-zip/) using pip.
+You can install stream-unzip and its dependencies from [PyPI](https://pypi.org/project/stream-unzip/) using pip.
 
 ```bash
 pip install stream-unzip


### PR DESCRIPTION
The getting started docs link to pypi points to the stream-zip package rather than the stream-unzip package