### PR TITLE
docs: add conda-forge package badge with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- --8<-- [start:intro] -->
 # stream-unzip
 
-[![PyPI package](https://img.shields.io/pypi/v/stream-unzip?label=PyPI%20package&color=%234c1)](https://pypi.org/project/stream-unzip/) [![Test suite](https://img.shields.io/github/actions/workflow/status/uktrade/stream-unzip/test.yml?label=Test%20suite)](https://github.com/uktrade/stream-unzip/actions/workflows/test.yml) [![Code coverage](https://img.shields.io/codecov/c/github/uktrade/stream-unzip?label=Code%20coverage)](https://app.codecov.io/gh/uktrade/stream-unzip)
+[![conda-forge package](https://img.shields.io/conda/v/conda-forge/stream-unzip?label=conda-forge&color=%234c1)](https://anaconda.org/conda-forge/stream-unzip) [![PyPI package](https://img.shields.io/pypi/v/stream-unzip?label=PyPI%20package&color=%234c1)](https://pypi.org/project/stream-unzip/) [![Test suite](https://img.shields.io/github/actions/workflow/status/uktrade/stream-unzip/test.yml?label=Test%20suite)](https://github.com/uktrade/stream-unzip/actions/workflows/test.yml) [![Code coverage](https://img.shields.io/codecov/c/github/uktrade/stream-unzip?label=Code%20coverage)](https://app.codecov.io/gh/uktrade/stream-unzip)
 
 Python function to stream unzip all the files in a ZIP archive, without loading the entire ZIP file into memory or any of its uncompressed files.
 <!-- --8<-- [end:intro] -->


### PR DESCRIPTION
This adds a conda-forge badge showing the current version of stream-unzip published to conda forge, with a link to the conda-forge page at https://anaconda.org/conda-forge/stream-unzip

<img width="536" alt="Screenshot 2023-11-26 at 14 10 05" src="https://github.com/uktrade/stream-unzip/assets/13877/105f01e4-38ed-482d-95f6-cbd09c4d2408">

----

While the package was added without knowledge of anyone involved with stream-unzip as far as I know, it seems a reasonable option for conda-based people to install stream-unzip, and allows other conda packages to depend on it as well from what I can tell.

I have also started the process of publishing stream-zip to conda-forge as well https://github.com/conda-forge/staged-recipes/pull/24588