### PR TITLE
fix: empty ZIP file raising UnexpectedSignatureError

### DIFF
--- a/stream_unzip.py
+++ b/stream_unzip.py
@@ -18,6 +18,7 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536, allow_zip64=Tr
     zip64_size_signature = b'\x01\x00'
     aes_extra_signature = b'\x01\x99'
     central_directory_signature = b'PK\x01\x02'
+    end_of_central_directory_signature = b'PK\x05\x06'
     unsigned_short = Struct('<H')
     unsigned_long_long = Struct('<Q')
 
@@ -449,7 +450,7 @@ def stream_unzip(zipfile_chunks, password=None, chunk_size=65536, allow_zip64=Tr
             signature = get_num(len(local_file_header_signature))
             if signature == local_file_header_signature:
                 yield yield_file(yield_all, get_num, return_num_unused, return_bytes_unused, get_offset_from_start)
-            elif signature == central_directory_signature:
+            elif signature in (central_directory_signature, end_of_central_directory_signature):
                 for _ in yield_all():
                     pass
                 break

--- a/test.py
+++ b/test.py
@@ -379,6 +379,16 @@ class TestStreamUnzip(unittest.TestCase):
 
         self.assertEqual(files, [(b'first.txt', 0, b'')])
 
+    def test_empty_zip(self):
+        def yield_input():
+            file = io.BytesIO()
+            with zipfile.ZipFile(file, 'w', zipfile.ZIP_DEFLATED) as zf:
+                pass
+
+            yield file.getvalue()
+
+        self.assertEqual(list(stream_unzip(yield_input())), [])
+
     def test_not_zip(self):
         with self.assertRaises(UnexpectedSignatureError):
             next(stream_unzip([b'This is not a zip file']))


### PR DESCRIPTION
This fixes the issues raised in
https://github.com/uktrade/stream-unzip/issues/77 where a ZIP file that has no members would raise

UnexpectedSignatureError: b'PK\x05\x06'

There was an assumption in the code that either there would be no bytes at all, or there would be some bytes and at least one member.

(I'm not entirely sure that no bytes should be treated as a valid ZIP come to think of it... but leaving that behaviour as it was)