### PR TITLE
docs: add links to footer

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -12,6 +12,20 @@ module.exports = function(eleventyConfig) {
         html: fs.readFileSync('./docs/assets/dit-logo.svg', {encoding: 'utf8'})
       },
       productName: 'stream-unzip',
+    },
+    footer: {
+      meta: {
+        items: [
+          {
+            href: 'https://github.com/uktrade/stream-unzip',
+            text: 'GitHub repository for stream-unzip'
+          },
+          {
+            href: 'https://www.gov.uk/government/organisations/department-for-business-and-trade',
+            text: 'Created by the Department for Business and Trade (DBT)'
+          }
+        ]
+      }
     }
   })
 


### PR DESCRIPTION
Add links to both the GitHub repo, and the gov.uk page for the department. This is to give the page a little bit more context, easier navigation to the repo, and a hint as to what the DBT at the top means.