### PR TITLE
feat: async interface (via threads)

### DIFF
--- a/docs/async-interface.md
+++ b/docs/async-interface.md
@@ -1,0 +1,46 @@
+---
+layout: sub-navigation
+order: 3
+title: Async interface
+---
+
+
+An async interface is provided via the function `async_stream_unzip`. Its usage is exactly the same as `stream_zip` except that:
+
+1. The input must be an async iterable of bytes.
+2. The member files are output as an async iterable of tuples.
+3. The data of each member file is returned as an async iterable of bytes.
+
+```python
+from stream_unzip import async_stream_unzip
+import httpx
+
+async def zipped_chunks(client):
+    # Iterable that yields the bytes of a zip file
+    async with client.stream('GET', 'https://www.example.com/my.zip') as r:
+        async for chunk in r.aiter_bytes(chunk_size=65536):
+            yield chunk
+
+async def main():
+    async with httpx.AsyncClient() as client:
+        async for file_name, file_size, unzipped_chunks in async_stream_unzip(
+                zipped_chunks(client),
+                password=b'my-password',
+        ):
+            async for chunk in unzipped_chunks:
+                print(chunk)
+
+asyncio.run(main())
+```
+
+> ### Warnings
+>
+> Under the hood `async_stream_unzip` uses threads as a layer over the synchronous `stream_unzip` function. This has two consequences:
+>
+> 1. A possible performance penalty over a theoretical implementation that is pure async without threads.
+>
+> 2. The [contextvars](https://docs.python.org/3/library/contextvars.html) context available in the async iterables of files or data is a shallow copy of the context where async_stream_unzip is called from.
+>
+>   This means that existing context variables are available inside the input iterable, but any changes made to the context itself from inside the iterable will not propagate out to the original context. Changes made to mutable data structures that are part of the context, for example dictionaries, will propagate out.
+>
+>   This does not affect Python 3.6, because contextvars is not available.

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 3
+order: 4
 title: Exceptions
 ---
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,3 +20,5 @@ In addition to being memory efficient, stream-unzip supports:
 - ZIP files created by Java's ZipOutputStream that are larger than 4GiB. At the time of writing libarchive-based stream readers cannot read these without error.
 
 - BZip2-compressed ZIPs.
+
+- An async interface (that uses threads under the hood).

--- a/docs/publish-a-release.md
+++ b/docs/publish-a-release.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 5
+order: 6
 title: How to publish a release
 ---
 


### PR DESCRIPTION
This adds a function, async_stream_unzip, that's the async version of stream_unzip.

It's inspired by the code and discussion in the PR at https://github.com/uktrade/stream-unzip/pull/80. However, to avoid duplication, we have a threads-based layer to call into the existing stream_unzip function, rather than have an almost identical copy but with async/await where needed in it. This is similar to how https://github.com/uktrade/stream-zip provides an async interface.