### PR TITLE
feat: add option allowed_encryption_mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ In addition to being memory efficient, stream-unzip supports:
 
 - Zip64 ZIP files. These are ZIP files that allow sizes far beyond the approximate 4GiB limit of the original ZIP format.
 
-- WinZip-style AES-encrypted ZIPs. Python's zipfile module cannot open AES-encrypted ZIPs.
+- WinZip-style AES-encrypted / password-protected ZIPs. Python's zipfile module cannot open AES-encrypted ZIPs.
 
-- Legacy-encrypted ZIP files. This is also known as ZipCrypto/Zip 2.0.
+- Legacy-encrypted / password-protected ZIP files. This is also known as ZipCrypto/Zip 2.0.
 
 - ZIP files created by Java's ZipOutputStream that are larger than 4GiB. At the time of writing libarchive-based stream readers cannot read these without error.
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -50,6 +50,39 @@ Exceptions raised by the source iterable are passed through `stream_unzip` uncha
 
                     An incorrect password was supplied for an AES encrypted file.
 
+            - **EncryptionMechanismNotAllowed**
+
+                Base class for errors where a member file is encountered with an encryption mechanism that is not allowed according to the `allowed_encryption_mechanisms` parameter. Not being encrypted at all is classed as an encryption mechanism.
+
+                - **FileIsNotEncrypted**
+
+                    The current member file in the ZIP is not encrypted, but NO_ENCRYPTION was not passed as in the `allowed_encryption_mechanisms` parameter to allow this.
+
+                - **ZipCryptoNotAllowed**
+
+                    The current member file is encrypted with the ZipCrypto mechanim, but ZIP_CRYPTO was not passed in the `allowed_encryption_mechanisms` to allow this.
+
+                - **AE1NotAllowed**
+
+                    The current member file is encrypted with AE-1, but AE_1 was not passed in the `allowed_encryption_mechanisms` to allow this.
+
+                - **AE2NotAllowed**
+
+                    The current member file is encrypted with AE-2, but AE_2 was not passed in the `allowed_encryption_mechanisms`
+
+                - **AES128NotAllowed**
+
+                    The current member file is encrypted with AES 128, but AES_128 was not passed in the `allowed_encryption_mechanisms` to allow this.
+
+                - **AES192NotAllowed**
+
+                    The current member file is encrypted with AES 192, but AES_192 was not passed in the `allowed_encryption_mechanisms` to allow this.
+
+                - **AES256NotAllowed**
+
+                    The current member file is encrypted with AES 256, but AES_256 was not passed in the `allowed_encryption_mechanisms` to allow this.
+
+
         - **DataError**
 
             An issue with the ZIP bytes themselves was encountered.

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,9 +13,9 @@ In addition to being memory efficient, stream-unzip supports:
 
 - Zip64 ZIP files. These are ZIP files that allow sizes far beyond the approximate 4GiB limit of the original ZIP format.
 
-- WinZip-style AES-encrypted ZIPs. Python's zipfile module cannot open AES-encrypted ZIPs.
+- WinZip-style AES-encrypted / password-protected ZIPs. Python's zipfile module cannot open AES-encrypted ZIPs.
 
-- Legacy-encrypted ZIP files. This is also known as ZipCrypto/Zip 2.0.
+- Legacy-encrypted / password-protected ZIP files. This is also known as ZipCrypto/Zip 2.0.
 
 - ZIP files created by Java's ZipOutputStream that are larger than 4GiB. At the time of writing libarchive-based stream readers cannot read these without error.
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -36,10 +36,66 @@ def zipped_chunks():
     with httpx.stream('GET', 'https://www.example.com/my.zip') as r:
         yield from r.iter_bytes(chunk_size=65536)
 
-for file_name, file_size, unzipped_chunks in stream_unzip(zipped_chunks(), password=b'my-password'):
+for file_name, file_size, unzipped_chunks in stream_unzip(zipped_chunks()):
     # unzipped_chunks must be iterated to completion or UnfinishedIterationError will be raised
     for chunk in unzipped_chunks:
         print(chunk)
 ```
 
 The file name and file size are extracted as reported from the file. If you don't trust the creator of the ZIP file, these should be treated as untrusted input.
+
+
+## Decrypting password protected files
+
+The `stream_unzip` function can decrypt password-protected ZIP files by passing a `bytes` instance password as the `password` argument. The basic usage is as follows.
+
+```python
+from stream_unzip import stream_unzip
+
+for file_name, file_size, unzipped_chunks in stream_unzip(zipped_chunks(), password=b'my-password'):
+    for chunk in unzipped_chunks:
+        pass
+```
+
+This by default decrypts files encrypted with ZipCrypto, WinZip's AE-1 and AE-2 that use any of AES 128, 192 and 256, and silently allows member files that are not password-protected at all even if a password has been passed. For security reasons, for example to give a stronger guarantee a file has not been modified during transit, you can tighten this, and only allow certain encryption mechanisms. You can do this by overriding the `allowed_encryption_mechanisms` argument. The default behaviour of allowing all mechanisms is shown below.
+
+```python
+from stream_unzip import stream_unzip, NO_ENCRYPTION, ZIP_CRYPTO, AE_1, AE_2, AES_128, AES_192, AES_256
+
+for file_name, file_size, unzipped_chunks in stream_unzip(
+    zipped_chunks(),
+    password=b'my-password', allowed_encryption_mechanisms=(
+        NO_ENCRYPTION,
+        ZIP_CRYPTO,
+        AE_1,
+        AE_2,
+        AES_128,
+        AES_192,
+        AES_256,
+    ),
+):
+    for chunk in unzipped_chunks:
+        pass
+```
+
+To forbid a mechanism remove its corresponding constant from the tuple passed as the `allowed_encryption_mechanisms` parameter. If a password is supplied but a file is encrypted with a mechanism not allowed by the `allowed_encryption_mechanisms` parameter, an exception will be raised.
+
+Note that the decryption of AES-encrypted ZIP files requires a combination of at least one of the AE_* constants, and at least one of the AES_* constants. The most secure combination would be AE_2 and AE_256, as in the following example.
+
+```python
+from stream_unzip import stream_unzip, AE_2, AES_256
+
+for file_name, file_size, unzipped_chunks in stream_unzip(
+    zipped_chunks(),
+    password=b'my-password', allowed_encryption_mechanisms=(
+        AE_2,
+        AES_256,
+    ),
+):
+    for chunk in unzipped_chunks:
+        pass
+```
+
+Future versions of stream-unzip fewer mechanisms may have a stricter default, for example by only allowing AE-2 with AES 256 as in this example.
+
+While the ZIP format allows for a different password per member file, stream-unzip only allows a single password that is applied to all the member files. Also, if no password is supplied, the `allowed_encryption_mechanisms` parameter is ignored, which means non-encrypted files will be uncompressed until reaching an encrypted file at which point an exception will be raised.


### PR DESCRIPTION
Inspired by the discussion at https://github.com/uktrade/stream-unzip/discussions/96, this adds the option allow_encryption_mechanisms for client code to pass a list of allowed encryption mechanisms, and so raises an exception if a file in the ZIP does not match the allowed mechanisms.

The default is the existing behaviour - all mechanisms are allowed. However, am tempted to only allow AES 256 by default in future releases for the default of highest security possible.