### PR TITLE
feat: trio support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.7.1"
             os: "ubuntu-20.04"
+          - python-version: "3.7.2"
+            os: "ubuntu-20.04"
           - python-version: "3.8.0"
             os: "ubuntu-20.04"
           - python-version: "3.9.0"

--- a/docs/async-interface.md
+++ b/docs/async-interface.md
@@ -33,6 +33,8 @@ async def main():
 asyncio.run(main())
 ```
 
+The async interface is compatible with both [asyncio](https://docs.python.org/3/library/asyncio.html) and [trio](https://github.com/python-trio/trio).
+
 > ### Warnings
 >
 > Under the hood `async_stream_unzip` uses threads as a layer over the synchronous `stream_unzip` function. This has two consequences:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
     "coverage>=6.2",
     "pytest>=6.2.5",
     "pytest-cov>=3.0.0",
+    "trio>=0.19.0",
 ]
 ci = [
     "pycryptodome==3.10.1",
@@ -33,6 +34,7 @@ ci = [
     "coverage==6.2",
     "pytest==6.2.5",
     "pytest-cov==3.0.0",
+    "trio==0.19.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Although there are a number of asyncio/trio differences, it looks like a "async compatibility layer" to call the sync stream_unzip function from an async context is basically the same for both, but just:

- With a bit of faff to work out if we're running in asyncio or trio
- And some slightly different function calls to run a sync function in a thread or to run an async function from that thread.

Requested in https://github.com/uktrade/stream-unzip/issues/98