### PR TITLE
docs: add limitations

### DIFF
--- a/docs/async-interface.md
+++ b/docs/async-interface.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 3
+order: 4
 title: Async interface
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 4
+order: 6
 title: How to contribute
 ---
 

--- a/docs/exceptions.md
+++ b/docs/exceptions.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 4
+order: 5
 title: Exceptions
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,0 +1,10 @@
+---
+layout: sub-navigation
+order: 3
+title: Limitations
+---
+
+
+Most ZIP files are stream-unzippable, however for technical reasons some are not. If a file is found to not be stream-unzippable, a NotStreamUnzippable exception will be raised.
+
+The only way to address this is to change how the file is created. All member files in the ZIP must either be stored compressed, or stored without a "data descriptor", or if it has a non-zero length its length must be given in its "local header". Explanations of these terms can be found in the ZIP specification: [APPNOTE](https://support.pkware.com/pkzip/appnote).

--- a/docs/publish-a-release.md
+++ b/docs/publish-a-release.md
@@ -1,6 +1,6 @@
 ---
 layout: sub-navigation
-order: 6
+order: 7
 title: How to publish a release
 ---
 


### PR DESCRIPTION
Prompted by the issue raised at https://github.com/uktrade/stream-unzip/issues/105, realised it's not obvious that not all files are stream-unzippable. So adding this information to the docs.