### PR TITLE
fix: missing main import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,14 @@
 version = 3
 
 [[package]]
+name = "_zipcrypto"
+version = "0.1.0"
+dependencies = [
+ "crc32-v2",
+ "pyo3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,14 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "stream_unzip_zipcrypto_decrypt"
-version = "0.1.0"
-dependencies = [
- "crc32-v2",
- "pyo3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "stream_unzip_zipcrypto_decrypt"
+name = "_zipcrypto"
 version = "0.1.0"
 edition = "2021"
 
 [lib]
-name = "stream_unzip_zipcrypto_decrypt"
+name = "_zipcrypto"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=0.12,<0.13"]
+requires = ["maturin>=1.7.4,<2.0.0"]
 build-backend = "maturin"
 
 [project]
@@ -38,7 +38,5 @@ ci = [
 "Source" = "https://github.com/uktrade/stream-unzip"
 
 [tool.maturin]
-include = [
-  "stream_unzip.py",
-  "src/**"
-]
+python-source = "python"
+module-name = "stream_unzip._zipcrypto"

--- a/python/stream_unzip/__init__.py
+++ b/python/stream_unzip/__init__.py
@@ -11,7 +11,7 @@ from Crypto.Protocol.KDF import PBKDF2
 
 from stream_inflate import stream_inflate64
 
-from stream_unzip_zipcrypto_decrypt import zipcrypto_decryptor
+from ._zipcrypto import zipcrypto_decryptor
 
 
 NO_ENCRYPTION = object()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,8 @@ impl StreamUnzipZipCryptoDecryptor {
 }
 
 #[pymodule]
-fn stream_unzip_zipcrypto_decrypt(m: &Bound<'_, PyModule>) -> PyResult<()> {
+#[pyo3(name="_zipcrypto")]
+fn zipcrypto(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<StreamUnzipZipCryptoDecryptor>()?;
     Ok(())
 }


### PR DESCRIPTION
Using a more recent maturin, and closer to what is documented as the recommended structure for a mixed Python/Rust project.

This should fix the issue reported at https://github.com/uktrade/stream-unzip/issues/111