### PR TITLE
ci: fix arm7l release by adding cargo

### DIFF
--- a/.github/workflows/deploy-package-to-pypi.yml
+++ b/.github/workflows/deploy-package-to-pypi.yml
@@ -111,7 +111,7 @@ jobs:
         run: >-
           docker run --rm -v ${{ github.workspace }}:/app quay.io/pypa/${{ matrix.image }} bash -c '
             cd /app &&
-            apk add rust &&
+            apk add rust cargo &&
             /opt/python/${{ matrix.folder }}/bin/python -m build --wheel &&
             auditwheel repair $(ls dist/*.whl) &&
             rm dist/*.whl &&


### PR DESCRIPTION
maturin, that builds the Rust-based library for ZipCrypto decryption, needs cargo as well as rust