### PR TITLE
Fix GitHub pages deploy permissions

### DIFF
--- a/.github/workflows/deploy-docs-to-github-pages.yml
+++ b/.github/workflows/deploy-docs-to-github-pages.yml
@@ -8,15 +8,17 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pages: write
+      id-token: write
       pull-requests: write
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
     - name: Setup Pages
-      uses: actions/configure-pages@v3
+      uses: actions/configure-pages@v5
     - name: Install dependencies
       run: npm ci
     - name: Build with Eleventy
@@ -28,6 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What
Adds more permissions to the build job in `deploy-docs-to-github-pages.yml`.
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
This task was failing, likely due to incorrect permissions.
<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [ ] I have tested locally
- [x] Testing not required

## Reviewer Checklist

- [x] I have reviewed the PR and ensured no secret values are present
