### PR TITLE
docs: correct title suffix

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -15,6 +15,7 @@ export default function(eleventyConfig) {
       },
       serviceName: 'stream-unzip,'
     },
+    titleSuffix: serviceName,
     showBreadcrumbs: false,
     serviceNavigation: {
       serviceName,


### PR DESCRIPTION


<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What

This changes the title suffix of pages from GOV.UK to the name of the Python package.


<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

This is because we should be not branding the site as an official GOV.UK service (even though it is fine for us to use the design system).



<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [x] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
