### PR TITLE
docs: fix the order of API pages in the menu

### DIFF
--- a/docs/api/functions.md
+++ b/docs/api/functions.md
@@ -3,7 +3,7 @@ layout: sub-navigation
 sectionKey: API reference
 eleventyNavigation:
     parent: API reference
-order: 2
+order: 1
 caption: API reference
 title: Functions
 ---


### PR DESCRIPTION

<!---
THIS PR TEMPLATE IS CURRENTLY UNDER DEVELOPMENT AND IS SUBJECT TO CHANGE
--->

## What

This fixes the order of API pages in its side menu - there were two pages with "2" as their order and it resulted in the order they appeared being non-deterministic.



<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why
This is done so the documentation is generated the same way every time, and so the menu items are in a fairly logical order.


<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [x] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
