### PR TITLE
docs: fix a number of typos and grammatical errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,13 +22,13 @@ To contribute changes to documentation or code, you will need the source of stre
 
 ### If you're a member of uktrade
 
-1. [Setup an SSH key and associate it with your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+1. [Setup an SSH key and associate it with your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
-2. Clone the repository
+2. Clone the repository.
 
     ```bash
     git clone git@github.com:uktrade/stream-unzip.git
-    cd stream-zup
+    cd stream-unzip
     ```
 
 You should not fork the repository if you're a member of uktrade.
@@ -45,7 +45,7 @@ You should not fork the repository if you're a member of uktrade.
 
     ```bash
     git clone git@github.com:my-username/stream-unzip.git
-    cd stream-zup
+    cd stream-unzip
     ```
 
 ## Documentation
@@ -77,7 +77,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add docs/getting-started.md  # Repeat for each file changed
     git commit -m "docs: add an example"
-    gir push origin docs/add-example
+    git push origin docs/add-example
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-unzip/pulls](https://github.com/uktrade/stream-unzip/pulls) against the `main` branch in stream-unzip.
@@ -108,17 +108,17 @@ Changes are then submitted via a Pull Request (PR). To do this:
 2. Make a branch using this descriptive name.
 
     ```bash
-    git checkout -b fix-a-bug-description
+    git checkout -b fix/the-bug-description
     ```
 
-3. Make sure you can run existing tests locally
+3. Make sure you can run existing tests locally.
 
     ```bash
     pip install -e ".[dev]"
     pytest
     ```
 
-4. Make your changes in a text editor. In the cases of changing behaviour, this would usually include changing or adding at least one test in [test_stream_zip.py](https://github.com/uktrade/stream-unzip/blob/main/test_stream_zip.py), and running them.
+4. Make your changes in a text editor. In the case of changing behaviour, this would usually include changing or adding at least one test in [test_stream_zip.py](https://github.com/uktrade/stream-unzip/blob/main/test_stream_zip.py), and running them.
 
     ```bash
     pytest
@@ -129,7 +129,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add stream_zip.py  # Repeat for each file changed
     git commit -m "feat: the bug description"
-    gir push origin fix/the-bug-description
+    git push origin fix/the-bug-description
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-unzip/pulls](https://github.com/uktrade/stream-unzip/pulls) against the `main` branch in stream-unzip.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To create ZIP files on the fly try [stream-zip](https://github.com/uktrade/strea
 
 In addition to being memory efficient, stream-unzip supports:
 
-- Deflate-compressed ZIPs. The is the historical standard for ZIP files.
+- Deflate-compressed ZIPs. This is the historical standard for ZIP files.
 
 - Deflate64-compressed ZIPs. These are created by certain versions of Windows Explorer in some circumstances. Python's zipfile module cannot open Deflate64-compressed ZIPs.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,7 @@ The `stream_unzip` module exposes two functions:
 
 ## Encryption types
 
-The `stream_unzip.stream_unzip` and `stream_unzip.async_stream_unzip` functions take a `allowed_encryption_mechanisms` argument that is a container of zero or more of the following constants:
+The `stream_unzip.stream_unzip` and `stream_unzip.async_stream_unzip` functions take an `allowed_encryption_mechanisms` argument, which is a container of zero or more of the following constants:
 
 - [`stream_unzip.NO_ENCRYPTION`](/api/encryption-types/#stream-unzip-no-encryption)
 - [`stream_unzip.ZIP_CRYPTO`](/api/encryption-types/#stream-unzip-zip-crypto)

--- a/docs/api/exception-hierarchy.md
+++ b/docs/api/exception-hierarchy.md
@@ -42,7 +42,7 @@ Exceptions raised by the source iterable are passed through the `stream_unzip.st
 
             - **IncorrectPasswordError**
 
-                An incorrect password was supplied. Note that due to nature of the ZIP file format, some incorrect passwords would not raise this exception, and instead raise a `DataError`, or even in pathalogical cases, not raise any exception.
+                An incorrect password was supplied. Note that due to the nature of the ZIP file format, some incorrect passwords would not raise this exception, and instead raise a `DataError`, or even in pathological cases, not raise any exception.
 
                 - **IncorrectZipCryptoPasswordError**
 
@@ -62,7 +62,7 @@ Exceptions raised by the source iterable are passed through the `stream_unzip.st
 
                 - **ZipCryptoNotAllowed**
 
-                    The current member file is encrypted with the ZipCrypto mechanim, but ZIP_CRYPTO was not passed in the `allowed_encryption_mechanisms` to allow this.
+                    The current member file is encrypted with the ZipCrypto mechanism, but ZIP_CRYPTO was not passed in the `allowed_encryption_mechanisms` to allow this.
 
                 - **AE1NotAllowed**
 
@@ -99,11 +99,11 @@ Exceptions raised by the source iterable are passed through the `stream_unzip.st
 
                 - **UnsupportedZip64Error**
 
-                    A Zip64 member file has been encounted but support has been disabled.
+                    A Zip64 member file has been encountered but support has been disabled.
 
                 - **NotStreamUnzippable**
 
-                    A member file has been encounted that is not stream unzippable.
+                    A member file has been encountered that is not stream unzippable.
 
                     The only way to address this is to change how the member file is created. It must either be created compressed, or without using a "data descriptor", or if the file has a non-zero length its length must be given in the "local header" of the member file.
 
@@ -153,7 +153,7 @@ Exceptions raised by the source iterable are passed through the `stream_unzip.st
 
             - **TruncatedExtraError**
 
-                Metadata known as *extra* that some ZIP files require is present, but too short.
+                Metadata known as *extra* that some ZIP files require is present, but is too short.
 
                 - **TruncatedZip64ExtraError**
 
@@ -161,7 +161,7 @@ Exceptions raised by the source iterable are passed through the `stream_unzip.st
 
             - **InvalidExtraError**
 
-                Metadata known as *extra* that some ZIP files require is present, long enough, but holds an invalid value.
+                Metadata known as *extra* that some ZIP files require is present and long enough, but holds an invalid value.
 
                 - **InvalidAESKeyLengthError**
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,13 +28,13 @@ To contribute changes to documentation or code, you will need the source of stre
 
 ### If you're a member of uktrade
 
-1. [Setup an SSH key and associate it with your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account)
+1. [Setup an SSH key and associate it with your GitHub account](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
-2. Clone the repository
+2. Clone the repository.
 
     ```bash
     git clone git@github.com:uktrade/stream-unzip.git
-    cd stream-zup
+    cd stream-unzip
     ```
 
 You should not fork the repository if you're a member of uktrade.
@@ -51,7 +51,7 @@ You should not fork the repository if you're a member of uktrade.
 
     ```bash
     git clone git@github.com:my-username/stream-unzip.git
-    cd stream-zup
+    cd stream-unzip
     ```
 
 ## Documentation
@@ -83,7 +83,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add docs/getting-started.md  # Repeat for each file changed
     git commit -m "docs: add an example"
-    gir push origin docs/add-example
+    git push origin docs/add-example
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-unzip/pulls](https://github.com/uktrade/stream-unzip/pulls) against the `main` branch in stream-unzip.
@@ -114,17 +114,17 @@ Changes are then submitted via a Pull Request (PR). To do this:
 2. Make a branch using this descriptive name.
 
     ```bash
-    git checkout -b fix-a-bug-description
+    git checkout -b fix/the-bug-description
     ```
 
-3. Make sure you can run existing tests locally
+3. Make sure you can run existing tests locally.
 
     ```bash
     pip install -e ".[dev]"
     pytest
     ```
 
-4. Make your changes in a text editor. In the cases of changing behaviour, this would usually include changing or adding at least one test in [test_stream_zip.py](https://github.com/uktrade/stream-unzip/blob/main/test_stream_zip.py), and running them.
+4. Make your changes in a text editor. In the case of changing behaviour, this would usually include changing or adding at least one test in [test_stream_zip.py](https://github.com/uktrade/stream-unzip/blob/main/test_stream_zip.py), and running them.
 
     ```bash
     pytest
@@ -135,7 +135,7 @@ Changes are then submitted via a Pull Request (PR). To do this:
     ```bash
     git add stream_zip.py  # Repeat for each file changed
     git commit -m "feat: the bug description"
-    gir push origin fix/the-bug-description
+    git push origin fix/the-bug-description
     ```
 
 6. Raise a PR at [https://github.com/uktrade/stream-unzip/pulls](https://github.com/uktrade/stream-unzip/pulls) against the `main` branch in stream-unzip.

--- a/docs/contributing/publish-a-release.md
+++ b/docs/contributing/publish-a-release.md
@@ -9,7 +9,7 @@ title: How to publish a release
 ---
 
 
-Only mambers of the uktrade GitHub organisation may publish a release. If you are a member of the uktrade GitHub organsation:
+Only members of the uktrade GitHub organisation may publish a release. If you are a member of the uktrade GitHub organsation:
 
 1. Go to the [stream-unzip GitHub releases page](https://github.com/uktrade/stream-unzip/releases).
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -21,7 +21,7 @@ pip install stream-unzip
 
 This installs the latest version of stream-unzip, and the latest compatible version of all of its dependencies.
 
-If you regularly install stream-unzip, such as during application deployment, to avoid unexpected changes as new versions are released, you can pin to specific versions. [Poetry](https://python-poetry.org/) or [pip-tools](https://pip-tools.readthedocs.io/en/latest/) are popular tools that can be used for this.
+To avoid unexpected changes as new versions are released you can pin to a specific version of stream-unzip. [Poetry](https://python-poetry.org/) or [pip-tools](https://pip-tools.readthedocs.io/en/latest/) are popular tools that can be used for this.
 
 
 ## Usage

--- a/docs/get-started/async-interface.md
+++ b/docs/get-started/async-interface.md
@@ -9,7 +9,7 @@ title: Async interface
 ---
 
 
-An async interface is provided via the function `async_stream_unzip`. Its usage is exactly the same as `stream_zip` except that:
+An async interface is provided via the function `async_stream_unzip`. Its usage is exactly the same as `stream_unzip` except that:
 
 1. The input must be an async iterable of bytes.
 2. The member files are output as an async iterable of tuples.

--- a/docs/get-started/features.md
+++ b/docs/get-started/features.md
@@ -11,7 +11,7 @@ title: Features
 
 In addition to being memory efficient, stream-unzip supports:
 
-- Deflate-compressed ZIPs. The is the historical standard for ZIP files.
+- Deflate-compressed ZIPs. This is the historical standard for ZIP files.
 
 - Deflate64-compressed ZIPs. These are created by certain versions of Windows Explorer in some circumstances. Python's zipfile module cannot open Deflate64-compressed ZIPs.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ startButton:
   </section>
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-7">
     <h2 class="govuk-heading-m govuk-!-font-size-27">Encryption</h2>
-    <p class="govuk-body">Supports WinZIP-style AES-encryption, as well legacy ZipCrypto/Zip 2.0.</p>
+    <p class="govuk-body">Supports WinZIP-style AES-encryption, as well as legacy ZipCrypto/Zip 2.0.</p>
   </section>
   <section class="govuk-grid-column-one-third-from-desktop govuk-!-margin-bottom-7">
     <h2 class="govuk-heading-m govuk-!-font-size-27">Large files</h2>
@@ -28,6 +28,6 @@ startButton:
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m govuk-!-font-size-27">Contributions</h2>
-    <p class="govuk-body">The code for stream-unzip is public and contributions are welcome though the <a class="govuk-link govuk-!-font-weight-bold" href="https://github.com/uktrade/stream-unzip">stream-unzip repository on GitHub</a>.</p>
+    <p class="govuk-body">The code for stream-unzip is public and contributions are welcome through the <a class="govuk-link govuk-!-font-weight-bold" href="https://github.com/uktrade/stream-unzip">stream-unzip repository on GitHub</a>.</p>
   </section>
 </div>


### PR DESCRIPTION


## What

This fixes a number of typos and grammatical errors in the documentation
<!---
What is this PR doing, e.g. implementations, algorithms, etc.?
 * Set the scene - you probably have a lot of context in your head that the reader doesn't have.
 * Explain like I'm 5 - try to make as few assumptions as possible about the reader
 * Use pictures, screenshots, or a diagram if you can, for example https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams
--->

## Why

So the docs are easier to understand and so hopefully then easier to use the package, as well as hopefully increasing trust a little bit.

<!---
Why is this change happening, e.g. goals, use cases, stories, etc.?
 * Explain what the problem was that this PR addresses.
 * Explain why this solution was chosen, and any alternatives considered.
 * Mention any assumptions, deliberately ignored edge-cases, or changes that are left for later.
--->

## How this has been tested

- [x] I have tested locally
- [ ] Testing not required

## Reviewer Checklist

- [ ] I have reviewed the PR and ensured no secret values are present
