### PR TITLE
chore: Updating SRE contact email address (SR-4422)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "stream-unzip"
 version = "0.0.0.dev0"
 authors = [
-  { name="Department for International Trade", email="sre@digital.trade.gov.uk" },
+  { name="Department for International Trade", email="sre@businessandtrade.gov.uk" },
 ]
 description = "Python function to stream unzip all the files in a ZIP archive, without loading the entire ZIP file into memory or any of its uncompressed files"
 readme = "README.md"


### PR DESCRIPTION
Work as part of SRE Jira ticket: https://uktrade.atlassian.net/browse/SR-4422. PR to update any existing references to sre@digital.trade.gov.uk, due to the upcoming deprecatiion of this inbox. SRE contact email address has been updated to sre@businessandtrade.gov.uk.